### PR TITLE
added kwargs, api_version can be specified

### DIFF
--- a/woof/consumer.py
+++ b/woof/consumer.py
@@ -58,13 +58,14 @@ class FeedConsumer(threading.Thread):
         self.wait_time_before_exit = wait_time_before_exit
 
         if use_zk:
-            kwargs['api_version'] = '0.8.1'
+            kwargs['api_version'] = kwargs.get('api_version', '0.8.1')
             # ZK autocommit does not seem to work reliably
             # TODO
             self.async_commit = False
 
         else:
-            kwargs['api_version'] = CURRENT_PROD_BROKER_VERSION
+            kwargs['api_version'] = kwargs.get('api_version',
+                                               CURRENT_PROD_BROKER_VERSION)
 
         try:
             self.cons = KafkaConsumer(

--- a/woof/producer.py
+++ b/woof/producer.py
@@ -13,13 +13,15 @@ class FeedProducer():
     use send() to send to any topic
     """
 
-    def __init__(self, broker, retries=3, async=False):
+    def __init__(self, broker, retries=3, async=False, **kwargs):
         try:
+            kwargs['api_version'] = kwargs.get('api_version',
+                                               CURRENT_PROD_BROKER_VERSION)
             self.prod = KafkaProducer(bootstrap_servers=broker,
                                       key_serializer=make_kafka_safe,
                                       value_serializer=make_kafka_safe,
                                       retries=retries,
-                                      api_version=CURRENT_PROD_BROKER_VERSION)
+                                      **kwargs)
             self.async = async
         except Exception as e:
             log.error("[feedproducer log] Constructor error ERROR %s  /n",

--- a/woof/transactions.py
+++ b/woof/transactions.py
@@ -15,19 +15,22 @@ class TransactionLogger(object):
                  vertical,
                  host=socket.gethostname(),
                  async=False,
-                 retries=1):
+                 retries=1,
+                 **kwargs):
         self.broker = broker
         self.this_host = host
         self.vertical = vertical
         self.async = async
         self.topic = _get_topic_from_vertical(vertical)
+        kwargs['api_version'] = kwargs.get('api_version',
+                                           CURRENT_PROD_BROKER_VERSION)
         # thread safe producer, uses default murmur2 partiioner by default
         # good for us
         self.producer = KafkaProducer(bootstrap_servers=broker,
                                       key_serializer=make_kafka_safe,
                                       value_serializer=make_kafka_safe,
-                                      api_version=CURRENT_PROD_BROKER_VERSION,
-                                      retries=retries)
+                                      retries=retries,
+                                      **kwargs)
 
     def New(self,
             txn_id,


### PR DESCRIPTION
1. Kwargs allowing additional parameters to parent class in kafka-python.
2. api_version, if not specified will fallback to CUREENT_PROD_VERSION='0.9'
