### PR TITLE
Make provision for passing custom serialisers in woof producer

### DIFF
--- a/woof/partitioned_producer.py
+++ b/woof/partitioned_producer.py
@@ -28,6 +28,8 @@ class PartitionedProducer(object):
                  batch_send_every_n=BATCH_SEND_MSG_COUNT,
                  batch_send_every_t=BATCH_SEND_DEFAULT_INTERVAL,  # unused  - here for legacy support
                  retries=3,
+                 key_serializer=make_kafka_safe,
+                 value_serializer=make_kafka_safe,
                  **kwargs):
 
         try:
@@ -39,8 +41,8 @@ class PartitionedProducer(object):
             kwargs['api_version'] = kwargs.get('api_version',
                                                CURRENT_PROD_BROKER_VERSION)
             self.prod = KafkaProducer(bootstrap_servers=broker,
-                                      key_serializer=make_kafka_safe,
-                                      value_serializer=make_kafka_safe,
+                                      key_serializer=key_serializer,
+                                      value_serializer=value_serializer,
                                       batch_size=batch_send_every_n,
                                       retries=retries,
                                       partitioner=_partitioner,
@@ -106,7 +108,13 @@ class CyclicPartitionedProducer(KafkaProducer):
     use send() to send to any topic and distribute keys cyclically in partitions
     """
 
-    def __init__(self, broker, async=True, random_start=True, **kwargs):
+    def __init__(self,
+                 broker,
+                 async=True,
+                 key_serializer=make_kafka_safe,
+                 value_serializer=make_kafka_safe,
+                 random_start=True,
+                 **kwargs):
         self.partition_cycles = {}
         self.random_start = random_start
         self.async = async
@@ -114,8 +122,8 @@ class CyclicPartitionedProducer(KafkaProducer):
                                            CURRENT_PROD_BROKER_VERSION)
         super(CyclicPartitionedProducer, self).__init__(
             bootstrap_servers=broker,
-            key_serializer=make_kafka_safe,
-            value_serializer=make_kafka_safe,
+            key_serializer=key_serializer,
+            value_serializer=value_serializer,
             **kwargs)
 
     def _partition(self, topic, partition, key, value, serialized_key,

--- a/woof/producer.py
+++ b/woof/producer.py
@@ -14,13 +14,19 @@ class FeedProducer(object):
     use send() to send to any topic
     """
 
-    def __init__(self, broker, retries=3, async=False, **kwargs):
+    def __init__(self,
+                 broker,
+                 key_serializer=make_kafka_safe,
+                 value_serializer=make_kafka_safe,
+                 retries=3,
+                 async=False,
+                 **kwargs):
         try:
             kwargs['api_version'] = kwargs.get('api_version',
                                                CURRENT_PROD_BROKER_VERSION)
             self.prod = KafkaProducer(bootstrap_servers=broker,
-                                      key_serializer=make_kafka_safe,
-                                      value_serializer=make_kafka_safe,
+                                      key_serializer=key_serializer,
+                                      value_serializer=value_serializer,
                                       retries=retries,
                                       **kwargs)
             self.async = async

--- a/woof/transactions.py
+++ b/woof/transactions.py
@@ -16,6 +16,8 @@ class TransactionLogger(object):
                  host=socket.gethostname(),
                  async=False,
                  retries=1,
+                 key_serializer=make_kafka_safe,
+                 value_serializer=make_kafka_safe,
                  **kwargs):
         self.broker = broker
         self.this_host = host
@@ -27,8 +29,8 @@ class TransactionLogger(object):
         # thread safe producer, uses default murmur2 partiioner by default
         # good for us
         self.producer = KafkaProducer(bootstrap_servers=broker,
-                                      key_serializer=make_kafka_safe,
-                                      value_serializer=make_kafka_safe,
+                                      key_serializer=key_serializer,
+                                      value_serializer=value_serializer,
                                       retries=retries,
                                       **kwargs)
 

--- a/woof/transactions.py
+++ b/woof/transactions.py
@@ -9,6 +9,19 @@ from common import CURRENT_PROD_BROKER_VERSION
 log = logging.getLogger("woof")
 
 
+def make_kafka_safe(raw_data):
+    """
+    This function was written to avoid non-unicode
+    string data produced to Kafka
+    """
+    if type(raw_data) != unicode:
+        raw_data = str(raw_data)
+        raw_data = raw_data.decode('utf-8')
+        return raw_data.encode('ascii', 'ignore')
+    else:
+        return raw_data.encode('ascii', 'ignore')
+
+
 class TransactionLogger(object):
     def __init__(self,
                  broker,
@@ -137,12 +150,3 @@ class TransactionLogger(object):
 
 def _get_topic_from_vertical(vertical):
     return "_".join(["TRANSACTIONS", vertical])
-
-
-def make_kafka_safe(raw_data):
-    if type(raw_data) != unicode:
-        raw_data = str(raw_data)
-        raw_data = raw_data.decode('utf-8')
-        return raw_data.encode('ascii', 'ignore')
-    else:
-        return raw_data.encode('ascii', 'ignore')


### PR DESCRIPTION
This patch will help anyone to write custom de-serialisation/serialisation protocols and produce binary data to Kafka. 

Say you want to deal with `msg pack` and not `UTF-8`. 

```python
# Producer 
producer = KafkaProducer(value_serializer=msgpack.dumps)
producer.send('msgpack-topic', {'key': 'value'})

# Consumer 
consumer = KafkaConsumer(value_deserializer=msgpack.unpackb)
for msg in consumer:
     do_something(msg) # here msg is de-serialised to python data structures.
```

FYI  - We wrote [make_safe](https://github.com/goibibo/woof/blob/master/woof/transactions.py#L140) earlier to stop anyone from producing non utf-8 string, now we will keep this as default but will allow anyone to override it. 